### PR TITLE
Removed sample announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,14 +135,6 @@ const config = {
           hideable: true,
         },
       },
-      announcementBar: {
-        id: "feedback_form",
-        content:
-          'We are looking to revamp our docs, please fill <a target="_blank" rel="noopener noreferrer" href="#">this survey</a>',
-        backgroundColor: "#fafbfc",
-        textColor: "#091E42",
-        isCloseable: true,
-      },
       navbar: {
         title: `${title}`,
         logo: {


### PR DESCRIPTION
The docusaurus sample repo has a sample announcement. I've removed it

![Screenshot 2024-10-16 at 17 43 06](https://github.com/user-attachments/assets/1f27d4b4-a4db-45b5-935c-447039ea8cf9)

Now you don't have to close it 👍 